### PR TITLE
Updating to ubuntu:lunar-20221216 (23.04) and squid 5.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM ubuntu:bionic-20190612
-LABEL maintainer="sameer@damagehead.com"
+FROM ubuntu:lunar-20221216
+# ubuntu:23.04
+LABEL maintainer="WingsLikeEagles"
 
-ENV SQUID_VERSION=3.5.27 \
+ENV SQUID_VERSION=5.7 \
     SQUID_CACHE_DIR=/var/spool/squid \
     SQUID_LOG_DIR=/var/log/squid \
     SQUID_USER=proxy
@@ -15,3 +16,6 @@ RUN chmod 755 /sbin/entrypoint.sh
 
 EXPOSE 3128/tcp
 ENTRYPOINT ["/sbin/entrypoint.sh"]
+
+# Uncomment below for troubleshooting build
+#CMD /bin/watch ls -l


### PR DESCRIPTION
Updating to latest Ubuntu image and latest Squid.  The new Ubuntu image requires a newer Docker Engine version. 

On Mac, you can restart the Application by using `open -a Docker`
If you need to shutdown, and the GUI isn't working right... I hear this works, but I have not confirmed: `pkill -SIGHUP -f /Applications/Docker.app 'docker serve'`
https://stackoverflow.com/questions/54437744/how-to-start-docker-from-command-line-in-mac
